### PR TITLE
Dont cache fees

### DIFF
--- a/fee-relayer/src/fee-info.js
+++ b/fee-relayer/src/fee-info.js
@@ -1,14 +1,9 @@
-
-let feeInfo = null
-
 module.exports = {
   getFeeInfo: async function (childChain, currency) {
+    const fees = (await childChain.getFees())['1']
+    const feeInfo = fees.find(fee => fee.currency.toLowerCase() === currency.toLowerCase())
     if (!feeInfo) {
-      const fees = (await childChain.getFees())['1']
-      feeInfo = fees.find(fee => fee.currency.toLowerCase() === currency.toLowerCase())
-      if (!feeInfo) {
-        throw new Error(`Configured FEE_TOKEN ${currency} is not a supported fee token`)
-      }
+      throw new Error(`Configured FEE_TOKEN ${currency} is not a supported fee token`)
     }
     return feeInfo
   }


### PR DESCRIPTION
when fees change transaction will fail.
we could poll.. but transactions could still fail between a fee update and the next poll.
i think the load of calling fees.all on every tx to the watcher is not much.